### PR TITLE
RNA transcription cleanup

### DIFF
--- a/rna-transcription/rna-transcription_test.lua
+++ b/rna-transcription/rna-transcription_test.lua
@@ -14,7 +14,7 @@ describe("to_rna()", function()
     assert.are.equal('U', to_rna('A'))
   end)
 
-  it("transcribes thymidine to adenosine", function()
+  it("transcribes thymine to adenosine", function()
     assert.are.equal('A', to_rna('T'))
   end)
 


### PR DESCRIPTION
Replaced 'cytidine' with 'cytosine' and 'thymidine' with 'thymine'.  Capitalized DNA and RNA.  Fixed ordering of expected and actual values in assertions.  Formatted for consistency with other exercises and to improve adherence to the provided style guide.
