### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -911,11 +911,6 @@
         "arrays",
         "bitwise operations"
       ]
-    },
-    {
-      "uuid": "121732a1-e3a3-4791-9b83-ec8a61969d85",
-      "slug": "accumulate",
-      "deprecated": true
     }
   ],
   "foregone": [

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     {
       "uuid": "9099df24-f9fb-4bd0-8b7f-df52efed7840",
       "slug": "hello-world",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
@@ -20,7 +20,7 @@
     {
       "uuid": "23fde0b3-c57b-439f-a9ad-3cd6ae286b62",
       "slug": "hamming",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -31,7 +31,7 @@
     {
       "uuid": "f38cd7b3-e1e6-4bcf-b1fe-c63ed94df636",
       "slug": "house",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -44,7 +44,7 @@
       "uuid": "faaa79ba-ddfa-42dd-8668-4aa811757dee",
       "slug": "raindrops",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 1,
       "topics": [
         "strings",
@@ -55,7 +55,7 @@
       "uuid": "9646d991-e3ad-475e-9231-c5723a73e57b",
       "slug": "bob",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -65,7 +65,7 @@
     {
       "uuid": "b985299f-c6eb-487e-9900-1b35a6e66dea",
       "slug": "difference-of-squares",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -76,7 +76,7 @@
       "uuid": "312d3e2f-ac24-4e06-8e6c-f4651124c516",
       "slug": "variable-length-quantity",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "run-length-encoding",
       "difficulty": 6,
       "topics": [
         "control-flow (if-else statements)",
@@ -89,7 +89,7 @@
       "uuid": "c8ac2fca-fdec-4562-9c60-fdee5b541186",
       "slug": "anagram",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "isogram",
       "difficulty": 6,
       "topics": [
         "strings",
@@ -102,7 +102,7 @@
       "uuid": "b64e6544-4778-40e8-a216-86df5c366c9c",
       "slug": "octal",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary",
       "difficulty": 4,
       "topics": [
         "strings",
@@ -114,7 +114,7 @@
     {
       "uuid": "2c50d23c-c15c-42d5-bc48-48afd21cdcf9",
       "slug": "binary-search",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -129,7 +129,7 @@
       "uuid": "25f501e6-40e8-4fd0-9dc3-ce5504d7a7a7",
       "slug": "bracket-push",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary-search",
       "difficulty": 5,
       "topics": [
         "stacks",
@@ -143,7 +143,7 @@
       "uuid": "c976a2aa-aaa8-42b5-9666-8f9d8b16b27c",
       "slug": "flatten-array",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary-search",
       "difficulty": 5,
       "topics": [
         "arrays",
@@ -157,7 +157,7 @@
       "uuid": "a15f48db-7f35-4a20-8830-e3eb91db164f",
       "slug": "word-count",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "isogram",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -168,7 +168,7 @@
       "uuid": "32724558-411b-4945-95fe-aaf3eae6daf2",
       "slug": "pangram",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "isogram",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -179,7 +179,7 @@
     {
       "uuid": "cfcefc94-cc73-4438-a62f-15c63a70bf5e",
       "slug": "matrix",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -192,7 +192,7 @@
       "uuid": "38b18de8-d0d9-4a4d-934f-2893b1f1ce45",
       "slug": "beer-song",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "house",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -204,7 +204,7 @@
     {
       "uuid": "3e70727a-1839-4ccf-8205-f2c8455cfdd1",
       "slug": "isogram",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -217,7 +217,7 @@
       "uuid": "d781a53f-8eb8-44d0-8ded-57d943225604",
       "slug": "perfect-numbers",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "difference-of-squares",
       "difficulty": 3,
       "topics": [
         "mathematics",
@@ -229,7 +229,7 @@
       "uuid": "c4846231-c68b-46cf-abe0-9e0b9f7c2825",
       "slug": "etl",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "list-ops",
       "difficulty": 3,
       "topics": [
         "transforming",
@@ -240,7 +240,7 @@
       "uuid": "903e3be6-cefd-4db5-b3dc-a325c4bcae7a",
       "slug": "nucleotide-count",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -252,7 +252,7 @@
       "uuid": "50425ddf-fbec-4740-99eb-14cb7cc8a78a",
       "slug": "food-chain",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "house",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -264,7 +264,7 @@
       "uuid": "39bb7747-23e3-4d96-880d-2af302b0c328",
       "slug": "sum-of-multiples",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "difference-of-squares",
       "difficulty": 2,
       "topics": [
         "mathematics",
@@ -276,7 +276,7 @@
       "uuid": "a42ea84d-030a-446b-8537-0bef558320df",
       "slug": "rna-transcription",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -288,7 +288,7 @@
       "uuid": "c2130674-fe39-4e40-a1b5-b6b6ea24e255",
       "slug": "phone-number",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "allergies",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -299,7 +299,7 @@
     {
       "uuid": "ffde0b07-d6b1-4b55-94d9-ec564817cbb8",
       "slug": "bank-account",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -311,7 +311,7 @@
       "uuid": "7ffbdb77-a0a3-4bcf-8fb7-d3c34bdfcaf5",
       "slug": "protein-translation",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -324,7 +324,7 @@
       "uuid": "84f1b842-3c9b-4d96-93f1-e26577dc493f",
       "slug": "grade-school",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "bank-account",
       "difficulty": 4,
       "topics": [
         "classes",
@@ -334,7 +334,7 @@
     {
       "uuid": "f141a9a3-af4b-4257-92b8-f850a987cf49",
       "slug": "nth-prime",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -347,7 +347,7 @@
     {
       "uuid": "1c624b3f-7cf6-4896-90ff-11aec0d37059",
       "slug": "diamond",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -360,7 +360,7 @@
     {
       "uuid": "d70fae4a-b8a0-41ab-856f-e078fcb2f85c",
       "slug": "run-length-encoding",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
@@ -375,7 +375,7 @@
       "uuid": "23120234-680d-4505-96e8-e87d669f0234",
       "slug": "sublist",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "list-ops",
       "difficulty": 4,
       "topics": [
         "arrays",
@@ -386,7 +386,7 @@
     {
       "uuid": "4db71417-612a-41d2-9db4-d53fdc7d530c",
       "slug": "robot-name",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -399,7 +399,7 @@
       "uuid": "c603a44b-c027-4906-aaa9-11522a92e3cb",
       "slug": "robot-simulator",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "robot-name",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -411,7 +411,7 @@
       "uuid": "d9fbf011-73ea-4e00-b6e9-85d2418b8565",
       "slug": "pythagorean-triplet",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "difference-of-squares",
       "difficulty": 3,
       "topics": [
         "mathematics",
@@ -422,7 +422,7 @@
     {
       "uuid": "79c25dc6-d2d5-4089-8016-9c01fc2e53f8",
       "slug": "leap",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
@@ -434,7 +434,7 @@
       "uuid": "b10fd75b-53dd-4220-b76b-a2f1ed2d2ea2",
       "slug": "space-age",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 2,
       "topics": [
         "classes"
@@ -444,7 +444,7 @@
       "uuid": "2a38e35d-04ab-45b1-aaff-dab7c9b60306",
       "slug": "pascals-triangle",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "diamond",
       "difficulty": 5,
       "topics": [
         "mathematics",
@@ -455,7 +455,7 @@
       "uuid": "4b5615e0-5c82-472e-84ed-f91b58ffc5c9",
       "slug": "sieve",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "nth-prime",
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -467,7 +467,7 @@
       "uuid": "1430571b-001a-4298-b834-1b6342d1c89a",
       "slug": "grains",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 2,
       "topics": [
         "control-flow (loops)"
@@ -477,7 +477,7 @@
       "uuid": "40e73366-3ee5-4190-99bc-fad839c59a40",
       "slug": "kindergarten-garden",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "allergies",
       "difficulty": 5,
       "topics": [
         "strings",
@@ -488,7 +488,7 @@
     {
       "uuid": "2530da0a-050c-472d-9f0c-cfe9045fb09f",
       "slug": "custom-set",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
@@ -502,7 +502,7 @@
       "uuid": "abe93c0d-a99c-4b58-a86a-3f96df09a186",
       "slug": "gigasecond",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 2,
       "topics": [
         "time"
@@ -512,7 +512,7 @@
       "uuid": "d7f4c19a-ac4c-4622-a5dd-e43b883365b8",
       "slug": "word-search",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 7,
       "topics": [
         "strings",
@@ -524,7 +524,7 @@
       "uuid": "3f8cc956-0f54-441f-b25a-c97390750bb6",
       "slug": "luhn",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "run-length-encoding",
       "difficulty": 4,
       "topics": [
         "strings",
@@ -536,7 +536,7 @@
       "uuid": "f3963d89-aacd-4502-ab60-b2fb127b30a5",
       "slug": "triangle",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "difference-of-squares",
       "difficulty": 3,
       "topics": [
         "control-flow (if-else statements)",
@@ -547,7 +547,7 @@
       "uuid": "a9e467c9-e820-49d8-aa45-542fcee4f112",
       "slug": "clock",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "bank-account",
       "difficulty": 3,
       "topics": [
         "classes"
@@ -557,7 +557,7 @@
       "uuid": "e96a4a0a-ac81-4969-ac50-93713958f06a",
       "slug": "series",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "list-ops",
       "difficulty": 4,
       "topics": [
         "coroutines",
@@ -569,7 +569,7 @@
       "uuid": "530c358d-44e9-4b36-9ced-a1b633591a3d",
       "slug": "linked-list",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "custom-set",
       "difficulty": 4,
       "topics": [
         "classes",
@@ -581,7 +581,7 @@
       "uuid": "91cff99a-b182-4a6d-befb-ce716d290996",
       "slug": "ocr-numbers",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 7,
       "topics": [
         "strings",
@@ -591,7 +591,7 @@
     {
       "uuid": "464ef39f-8991-49f6-b6eb-5d811a262363",
       "slug": "pig-latin",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 5,
       "topics": [
@@ -605,7 +605,7 @@
       "uuid": "f41c1b0e-26e7-43d5-b1d2-106c08d6fa4a",
       "slug": "minesweeper",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 7,
       "topics": [
         "arrays",
@@ -619,7 +619,7 @@
       "uuid": "058b40fe-9ca7-4082-a525-8b01b5d3a632",
       "slug": "crypto-square",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "run-length-encoding",
       "difficulty": 5,
       "topics": [
         "strings",
@@ -630,7 +630,7 @@
     {
       "uuid": "71a6d7d8-938b-4a8f-a216-ec0e8326ea52",
       "slug": "list-ops",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -643,7 +643,7 @@
       "uuid": "bf78cd80-3f8d-4075-b893-ba4ded5bf179",
       "slug": "meetup",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "pig-latin",
       "difficulty": 6,
       "topics": [
         "time",
@@ -655,7 +655,7 @@
       "uuid": "49d08ed0-3a4a-44f6-beb3-ae086255e59f",
       "slug": "atbash-cipher",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "run-length-encoding",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -667,7 +667,7 @@
       "uuid": "4ec23243-6401-4be7-9770-1cd235da0557",
       "slug": "scrabble-score",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
         "strings",
@@ -678,7 +678,7 @@
       "uuid": "d2004df3-1cc5-4f78-a564-f66771425fd3",
       "slug": "largest-series-product",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "difference-of-squares",
       "difficulty": 5,
       "topics": [
         "control-flow (loops)",
@@ -689,7 +689,7 @@
       "uuid": "d1fedc2b-9771-49b5-b253-05e1337448c6",
       "slug": "rail-fence-cipher",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "run-length-encoding",
       "difficulty": 7,
       "topics": [
         "strings",
@@ -702,7 +702,7 @@
       "uuid": "5e38f418-d279-4d2f-a035-f440e59c4635",
       "slug": "roman-numerals",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 4,
       "topics": [
         "strings",
@@ -714,7 +714,7 @@
       "uuid": "a54806a0-d17c-4ae9-a48e-bc587eab93ea",
       "slug": "transpose",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 7,
       "topics": [
         "strings",
@@ -726,7 +726,7 @@
       "uuid": "d4a793a8-bd4a-478d-a4e2-ee20dd4b6085",
       "slug": "tournament",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "allergies",
       "difficulty": 5,
       "topics": [
         "arrays",
@@ -740,7 +740,7 @@
       "uuid": "5b636f8a-37ba-412d-b957-633caac86369",
       "slug": "circular-buffer",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "custom-set",
       "difficulty": 4,
       "topics": [
         "classes",
@@ -752,7 +752,7 @@
       "uuid": "84715ca7-b4cb-41bd-a5f0-1c45e372d834",
       "slug": "binary-search-tree",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary-search",
       "difficulty": 5,
       "topics": [
         "coroutines",
@@ -767,7 +767,7 @@
       "uuid": "6132095c-964f-4d58-9555-b4c77818e6d2",
       "slug": "bowling",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "allergies",
       "difficulty": 4,
       "topics": [
         "algorithms",
@@ -778,7 +778,7 @@
     {
       "uuid": "90fe2b43-5f4e-42fe-89ad-4fff49ccbb53",
       "slug": "binary",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
@@ -792,7 +792,7 @@
       "uuid": "26ea07b8-2658-47c2-9218-059c168ba1ea",
       "slug": "alphametics",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 8,
       "topics": [
         "strings",
@@ -806,7 +806,7 @@
       "uuid": "0f85f581-0077-447e-a5f4-7b58c1b4b7a8",
       "slug": "prime-factors",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "nth-prime",
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -818,7 +818,7 @@
       "uuid": "3f8c4f1b-b0b7-4f6e-8cd9-d5e252737ebb",
       "slug": "acronym",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "isogram",
       "difficulty": 4,
       "topics": [
         "strings",
@@ -829,7 +829,7 @@
       "uuid": "1ee89535-3e91-4404-9116-adcbf87f2390",
       "slug": "all-your-base",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary",
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -841,7 +841,7 @@
       "uuid": "6f2e38ae-57d8-4b4e-b1db-ae35c066ece4",
       "slug": "rectangles",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "matrix",
       "difficulty": 8,
       "topics": [
         "strings",
@@ -854,7 +854,7 @@
     {
       "uuid": "6e7a0d97-580b-4b21-bcad-e89e0473d507",
       "slug": "allergies",
-      "core": false,
+      "core": true,
       "unlocked_by": null,
       "difficulty": 4,
       "topics": [
@@ -867,7 +867,7 @@
       "uuid": "7159ffe2-3f5f-4d12-8a38-843452ef5d7e",
       "slug": "say",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "pig-latin",
       "difficulty": 7,
       "topics": [
         "strings",
@@ -879,7 +879,7 @@
       "uuid": "ba763756-e934-473f-a01c-a7c9ea0a971d",
       "slug": "pov",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary-search",
       "difficulty": 9,
       "topics": [
         "graphs",
@@ -893,7 +893,7 @@
       "uuid": "790d60b6-a64e-482f-8c2b-3e2442ac0b4e",
       "slug": "change",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "binary-search",
       "difficulty": 4,
       "topics": [
         "control-flow (if-else statements)",
@@ -904,7 +904,7 @@
       "uuid": "a608af44-59df-425d-a652-163635bf740e",
       "slug": "secret-handshake",
       "core": false,
-      "unlocked_by": null,
+      "unlocked_by": "leap",
       "difficulty": 3,
       "topics": [
         "control-flow (if-else statements)",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,10 @@
   "test_pattern": ".*spec[.]lua$",
   "exercises": [
     {
+      "uuid": "9099df24-f9fb-4bd0-8b7f-df52efed7840",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "control-flow (if-statements)",
@@ -15,7 +18,10 @@
       ]
     },
     {
+      "uuid": "23fde0b3-c57b-439f-a9ad-3cd6ae286b62",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "strings",
@@ -23,7 +29,10 @@
       ]
     },
     {
+      "uuid": "f38cd7b3-e1e6-4bcf-b1fe-c63ed94df636",
       "slug": "house",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -32,7 +41,10 @@
       ]
     },
     {
+      "uuid": "faaa79ba-ddfa-42dd-8668-4aa811757dee",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "strings",
@@ -40,7 +52,10 @@
       ]
     },
     {
+      "uuid": "9646d991-e3ad-475e-9231-c5723a73e57b",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -48,14 +63,20 @@
       ]
     },
     {
+      "uuid": "b985299f-c6eb-487e-9900-1b35a6e66dea",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "mathematics"
       ]
     },
     {
+      "uuid": "312d3e2f-ac24-4e06-8e6c-f4651124c516",
       "slug": "variable-length-quantity",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "control-flow (if-else statements)",
@@ -65,7 +86,10 @@
       ]
     },
     {
+      "uuid": "c8ac2fca-fdec-4562-9c60-fdee5b541186",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "strings",
@@ -75,7 +99,10 @@
       ]
     },
     {
+      "uuid": "b64e6544-4778-40e8-a216-86df5c366c9c",
       "slug": "octal",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -85,7 +112,10 @@
       ]
     },
     {
+      "uuid": "2c50d23c-c15c-42d5-bc48-48afd21cdcf9",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "arrays",
@@ -96,7 +126,10 @@
       ]
     },
     {
+      "uuid": "25f501e6-40e8-4fd0-9dc3-ce5504d7a7a7",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "stacks",
@@ -107,7 +140,10 @@
       ]
     },
     {
+      "uuid": "c976a2aa-aaa8-42b5-9666-8f9d8b16b27c",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "arrays",
@@ -118,7 +154,10 @@
       ]
     },
     {
+      "uuid": "a15f48db-7f35-4a20-8830-e3eb91db164f",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -126,7 +165,10 @@
       ]
     },
     {
+      "uuid": "32724558-411b-4945-95fe-aaf3eae6daf2",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -135,7 +177,10 @@
       ]
     },
     {
+      "uuid": "cfcefc94-cc73-4438-a62f-15c63a70bf5e",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "matrices",
@@ -144,7 +189,10 @@
       ]
     },
     {
+      "uuid": "38b18de8-d0d9-4a4d-934f-2893b1f1ce45",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -154,7 +202,10 @@
       ]
     },
     {
+      "uuid": "3e70727a-1839-4ccf-8205-f2c8455cfdd1",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "strings",
@@ -163,7 +214,10 @@
       ]
     },
     {
+      "uuid": "d781a53f-8eb8-44d0-8ded-57d943225604",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "mathematics",
@@ -172,7 +226,10 @@
       ]
     },
     {
+      "uuid": "c4846231-c68b-46cf-abe0-9e0b9f7c2825",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "transforming",
@@ -180,7 +237,10 @@
       ]
     },
     {
+      "uuid": "903e3be6-cefd-4db5-b3dc-a325c4bcae7a",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -189,7 +249,10 @@
       ]
     },
     {
+      "uuid": "50425ddf-fbec-4740-99eb-14cb7cc8a78a",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -198,7 +261,10 @@
       ]
     },
     {
+      "uuid": "39bb7747-23e3-4d96-880d-2af302b0c328",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "mathematics",
@@ -207,7 +273,10 @@
       ]
     },
     {
+      "uuid": "a42ea84d-030a-446b-8537-0bef558320df",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -216,7 +285,10 @@
       ]
     },
     {
+      "uuid": "c2130674-fe39-4e40-a1b5-b6b6ea24e255",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -225,7 +297,10 @@
       ]
     },
     {
+      "uuid": "ffde0b07-d6b1-4b55-94d9-ec564817cbb8",
       "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "classes",
@@ -233,7 +308,10 @@
       ]
     },
     {
+      "uuid": "7ffbdb77-a0a3-4bcf-8fb7-d3c34bdfcaf5",
       "slug": "protein-translation",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -243,7 +321,10 @@
       ]
     },
     {
+      "uuid": "84f1b842-3c9b-4d96-93f1-e26577dc493f",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "classes",
@@ -251,7 +332,10 @@
       ]
     },
     {
+      "uuid": "f141a9a3-af4b-4257-92b8-f850a987cf49",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -261,7 +345,10 @@
       ]
     },
     {
+      "uuid": "1c624b3f-7cf6-4896-90ff-11aec0d37059",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "control-flow (loops)",
@@ -271,7 +358,10 @@
       ]
     },
     {
+      "uuid": "d70fae4a-b8a0-41ab-856f-e078fcb2f85c",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "strings",
@@ -282,7 +372,10 @@
       ]
     },
     {
+      "uuid": "23120234-680d-4505-96e8-e87d669f0234",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "arrays",
@@ -291,7 +384,10 @@
       ]
     },
     {
+      "uuid": "4db71417-612a-41d2-9db4-d53fdc7d530c",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -300,7 +396,10 @@
       ]
     },
     {
+      "uuid": "c603a44b-c027-4906-aaa9-11522a92e3cb",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -309,7 +408,10 @@
       ]
     },
     {
+      "uuid": "d9fbf011-73ea-4e00-b6e9-85d2418b8565",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "mathematics",
@@ -318,7 +420,10 @@
       ]
     },
     {
+      "uuid": "79c25dc6-d2d5-4089-8016-9c01fc2e53f8",
       "slug": "leap",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
         "logic",
@@ -326,14 +431,20 @@
       ]
     },
     {
+      "uuid": "b10fd75b-53dd-4220-b76b-a2f1ed2d2ea2",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "classes"
       ]
     },
     {
+      "uuid": "2a38e35d-04ab-45b1-aaff-dab7c9b60306",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "mathematics",
@@ -341,7 +452,10 @@
       ]
     },
     {
+      "uuid": "4b5615e0-5c82-472e-84ed-f91b58ffc5c9",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -350,14 +464,20 @@
       ]
     },
     {
+      "uuid": "1430571b-001a-4298-b834-1b6342d1c89a",
       "slug": "grains",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "control-flow (loops)"
       ]
     },
     {
+      "uuid": "40e73366-3ee5-4190-99bc-fad839c59a40",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "strings",
@@ -366,7 +486,10 @@
       ]
     },
     {
+      "uuid": "2530da0a-050c-472d-9f0c-cfe9045fb09f",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "classes",
@@ -376,14 +499,20 @@
       ]
     },
     {
+      "uuid": "abe93c0d-a99c-4b58-a86a-3f96df09a186",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "time"
       ]
     },
     {
+      "uuid": "d7f4c19a-ac4c-4622-a5dd-e43b883365b8",
       "slug": "word-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "strings",
@@ -392,7 +521,10 @@
       ]
     },
     {
+      "uuid": "3f8cc956-0f54-441f-b25a-c97390750bb6",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -401,7 +533,10 @@
       ]
     },
     {
+      "uuid": "f3963d89-aacd-4502-ab60-b2fb127b30a5",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "control-flow (if-else statements)",
@@ -409,14 +544,20 @@
       ]
     },
     {
+      "uuid": "a9e467c9-e820-49d8-aa45-542fcee4f112",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "classes"
       ]
     },
     {
+      "uuid": "e96a4a0a-ac81-4969-ac50-93713958f06a",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "coroutines",
@@ -425,7 +566,10 @@
       ]
     },
     {
+      "uuid": "530c358d-44e9-4b36-9ced-a1b633591a3d",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "classes",
@@ -434,7 +578,10 @@
       ]
     },
     {
+      "uuid": "91cff99a-b182-4a6d-befb-ce716d290996",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "strings",
@@ -442,7 +589,10 @@
       ]
     },
     {
+      "uuid": "464ef39f-8991-49f6-b6eb-5d811a262363",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "strings",
@@ -452,7 +602,10 @@
       ]
     },
     {
+      "uuid": "f41c1b0e-26e7-43d5-b1d2-106c08d6fa4a",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "arrays",
@@ -463,7 +616,10 @@
       ]
     },
     {
+      "uuid": "058b40fe-9ca7-4082-a525-8b01b5d3a632",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "strings",
@@ -472,7 +628,10 @@
       ]
     },
     {
+      "uuid": "71a6d7d8-938b-4a8f-a216-ec0e8326ea52",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "arrays",
@@ -481,7 +640,10 @@
       ]
     },
     {
+      "uuid": "bf78cd80-3f8d-4075-b893-ba4ded5bf179",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
         "time",
@@ -490,7 +652,10 @@
       ]
     },
     {
+      "uuid": "49d08ed0-3a4a-44f6-beb3-ae086255e59f",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -499,7 +664,10 @@
       ]
     },
     {
+      "uuid": "4ec23243-6401-4be7-9770-1cd235da0557",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -507,7 +675,10 @@
       ]
     },
     {
+      "uuid": "d2004df3-1cc5-4f78-a564-f66771425fd3",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "control-flow (loops)",
@@ -515,7 +686,10 @@
       ]
     },
     {
+      "uuid": "d1fedc2b-9771-49b5-b253-05e1337448c6",
       "slug": "rail-fence-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "strings",
@@ -525,7 +699,10 @@
       ]
     },
     {
+      "uuid": "5e38f418-d279-4d2f-a035-f440e59c4635",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -534,7 +711,10 @@
       ]
     },
     {
+      "uuid": "a54806a0-d17c-4ae9-a48e-bc587eab93ea",
       "slug": "transpose",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "strings",
@@ -543,7 +723,10 @@
       ]
     },
     {
+      "uuid": "d4a793a8-bd4a-478d-a4e2-ee20dd4b6085",
       "slug": "tournament",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "arrays",
@@ -554,7 +737,10 @@
       ]
     },
     {
+      "uuid": "5b636f8a-37ba-412d-b957-633caac86369",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "classes",
@@ -563,7 +749,10 @@
       ]
     },
     {
+      "uuid": "84715ca7-b4cb-41bd-a5f0-1c45e372d834",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "coroutines",
@@ -575,7 +764,10 @@
       ]
     },
     {
+      "uuid": "6132095c-964f-4d58-9555-b4c77818e6d2",
       "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "algorithms",
@@ -584,7 +776,10 @@
       ]
     },
     {
+      "uuid": "90fe2b43-5f4e-42fe-89ad-4fff49ccbb53",
       "slug": "binary",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "strings",
@@ -594,7 +789,10 @@
       ]
     },
     {
+      "uuid": "26ea07b8-2658-47c2-9218-059c168ba1ea",
       "slug": "alphametics",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "strings",
@@ -605,7 +803,10 @@
       ]
     },
     {
+      "uuid": "0f85f581-0077-447e-a5f4-7b58c1b4b7a8",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -614,7 +815,10 @@
       ]
     },
     {
+      "uuid": "3f8c4f1b-b0b7-4f6e-8cd9-d5e252737ebb",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "strings",
@@ -622,7 +826,10 @@
       ]
     },
     {
+      "uuid": "1ee89535-3e91-4404-9116-adcbf87f2390",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "mathematics",
@@ -631,7 +838,10 @@
       ]
     },
     {
+      "uuid": "6f2e38ae-57d8-4b4e-b1db-ae35c066ece4",
       "slug": "rectangles",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "strings",
@@ -642,7 +852,10 @@
       ]
     },
     {
+      "uuid": "6e7a0d97-580b-4b21-bcad-e89e0473d507",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "bitwise operations",
@@ -651,7 +864,10 @@
       ]
     },
     {
+      "uuid": "7159ffe2-3f5f-4d12-8a38-843452ef5d7e",
       "slug": "say",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "strings",
@@ -660,7 +876,10 @@
       ]
     },
     {
+      "uuid": "ba763756-e934-473f-a01c-a7c9ea0a971d",
       "slug": "pov",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
         "graphs",
@@ -671,7 +890,10 @@
       ]
     },
     {
+      "uuid": "790d60b6-a64e-482f-8c2b-3e2442ac0b4e",
       "slug": "change",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "control-flow (if-else statements)",
@@ -679,17 +901,22 @@
       ]
     },
     {
+      "uuid": "a608af44-59df-425d-a652-163635bf740e",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "control-flow (if-else statements)",
         "arrays",
         "bitwise operations"
       ]
+    },
+    {
+      "uuid": "121732a1-e3a3-4791-9b83-ec8a61969d85",
+      "slug": "accumulate",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "accumulate"
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16