### PR TITLE
Add back deleted, deprecated accumulate exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -954,6 +954,11 @@
       ],
       "unlocked_by": "run-length-encoding",
       "uuid": "a9a6a2c7-2a58-4090-b538-5a275c521fe0"
+    },
+    {
+      "deprecated": true,
+      "slug": "accumulate",
+      "uuid": "70bc1661-9132-43af-bb44-b51e7d81676b"
     }
   ],
   "foregone": [],

--- a/exercises/accumulate/accumulate_spec.lua
+++ b/exercises/accumulate/accumulate_spec.lua
@@ -1,0 +1,27 @@
+local accumulate = require('accumulate')
+
+describe('accumulate', function()
+  local function square(x) return x * x end
+
+  it('should accumulate over an empty array', function()
+    assert.are.same({}, accumulate({}, square))
+  end)
+
+  it('should accumulate over an array with a single element', function()
+    assert.are.same({ 4 }, accumulate({ 2 }, square))
+  end)
+
+  it('should accumulate over an array with several elements', function()
+    assert.are.same({ 1, 4, 9 }, accumulate({ 1, 2, 3 }, square))
+  end)
+
+  it('should accumulate over an array with a different function', function()
+    assert.are.same({ 'HELLO', 'WORLD' }, accumulate({ 'hello', 'world' }, string.upper))
+  end)
+
+  it('should not modify the input array', function()
+    local input = { 1, 2, 3 }
+    accumulate(input, square)
+    assert.are.same({ 1, 2, 3 }, input)
+  end)
+end)

--- a/exercises/accumulate/example.lua
+++ b/exercises/accumulate/example.lua
@@ -1,0 +1,7 @@
+return function(xs, f)
+  local result = {}
+  for _, x in ipairs(xs) do
+    table.insert(result, f(x))
+  end
+  return result
+end


### PR DESCRIPTION
When migrating the data from v1 to v2, we will lose all the solutions submitted to
deprecated exercises, unless they exist in the track configuration.

This adds the deprecated accumulate exercise back, leaving it deprecated so that it
doesn't actively show up as part of the track.

We can delete it from the track again after we launch v2, if we want to.