### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -4,10 +4,15 @@
 {{- with .Hints }}
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+## Running the tests
+
+To run the tests, run the command `busted .` from within the exercise directory.
+
+## Further information
+
+For more detailed information about the Lua track, including how to get help if
+you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -1,8 +1,0 @@
-## Running the tests
-
-To run the tests, run the command `busted .` from within the exercise directory.
-
-## Further information
-
-For more detailed information about the Lua track, including how to get help if
-you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -40,6 +40,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -40,6 +40,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -35,6 +35,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -16,6 +16,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -1,4 +1,4 @@
-# Isbn Verifier
+# ISBN Verifier
 
 The [ISBN-10 verification process](https://en.wikipedia.org/wiki/International_Standard_Book_Number) is used to validate book identification
 numbers. These normally contain dashes and look like: `3-598-21508-8`

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -15,6 +15,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -35,6 +35,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -20,11 +20,11 @@ All subsequent codons after are ignored, like this:
 
 RNA: `"AUGUUUUCUUAAAUG"` =>
 
-Codons: `"AUG", "UUU", "UCU", "UAG", "AUG"` =>
+Codons: `"AUG", "UUU", "UCU", "UAA", "AUG"` =>
 
 Protein: `"Methionine", "Phenylalanine", "Serine"`
 
-Note the stop codon terminates the translation and the final methionine is not translated into the protein sequence.
+Note the stop codon `"UAA"` terminates the translation and the final methionine is not translated into the protein sequence.
 
 Below are the codons and resulting Amino Acids needed for the exercise.
 

--- a/exercises/react/README.md
+++ b/exercises/react/README.md
@@ -24,6 +24,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -72,6 +72,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -1,4 +1,4 @@
-# reverse-string
+# Reverse String
 
 Reverse a string
 

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -29,7 +29,7 @@ you're having trouble, please visit the exercism.io [Lua language page](http://e
 
 ## Source
 
-Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+Hyperphysics [http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html](http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html)
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -26,6 +26,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -73,6 +73,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -35,6 +35,5 @@ To run the tests, run the command `busted .` from within the exercise directory.
 For more detailed information about the Lua track, including how to get help if
 you're having trouble, please visit the exercism.io [Lua language page](http://exercism.io/languages/lua/about).
 
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94