### PR TITLE
install: add liblua5.3-dev as dependency

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -29,7 +29,7 @@ $ busted
 First install Lua and [Luarocks][2] using [Apt][6]:
 
 ```shell
-$ sudo apt-get install lua5.3 luarocks
+$ sudo apt-get install lua5.3 liblua5.3-dev luarocks
 ```
 
 Then install the [Busted][3] testing framework for Lua:


### PR DESCRIPTION
Luarocks needs lua include files it to compile some dependencies.

In my system busted's installation failed because lua include files were missing. 