### PR TITLE
binary-search: clearer failure messages for <= comparisons

### DIFF
--- a/exercises/binary-search/assertions.lua
+++ b/exercises/binary-search/assertions.lua
@@ -1,0 +1,15 @@
+local assert = require('luassert.assert')
+local say = require('say')
+
+local function lteq(state, arguments)
+  assert(#arguments == 2, 'expected two argument to assert.lteq')
+
+  local a = arguments[1]
+  local b = arguments[2]
+
+  return a <= b
+end
+
+say:set("assertion.lteq.positive", "Expected\n%s\nto be less than or equal to\n%s")
+say:set("assertion.lteq.negative", "Expected\n%s\nto not be less than or equal to\n%s")
+assert:register("assertion", "lteq", lteq, 'assertion.lteq.positive', 'assertion.lteq.negative')

--- a/exercises/binary-search/binary-search_spec.lua
+++ b/exercises/binary-search/binary-search_spec.lua
@@ -1,5 +1,6 @@
 local find = require('binary-search')
 local TracedArray = require('TracedArray')
+require('assertions')
 
 describe('binary-search', function()
   it('should return -1 when an empty array is searched', function()
@@ -33,34 +34,34 @@ describe('binary-search', function()
     local array = TracedArray{ 6, 67, 123, 345, 456, 457, 490, 2002, 54321, 54322 }
 
     assert.equal(8, find(array, 2002))
-    assert(array.access_count <= 4)
+    assert.lteq(array.access_count, 4)
   end)
 
   it('should find elements at the beginning of an array in less than log(n) accesses', function()
     local array = TracedArray{ 6, 67, 123, 345, 456, 457, 490, 2002, 54321, 54322 }
 
     assert.equal(1, find(array, 6))
-    assert(array.access_count <= 4)
+    assert.lteq(array.access_count, 4)
   end)
 
   it('should find elements at the end of an array in less than log(n) accesses', function()
     local array = TracedArray{ 6, 67, 123, 345, 456, 457, 490, 2002, 54321, 54322 }
 
     assert.equal(10, find(array, 54322))
-    assert(array.access_count <= 4)
+    assert.lteq(array.access_count, 4)
   end)
 
   it('should return -1 if a value is less than all elements in a long array', function()
     local array = TracedArray{ 6, 67, 123, 345, 456, 457, 490, 2002, 54321, 54322 }
 
     assert.equal(-1, find(array, 2))
-    assert(array.access_count <= 4)
+    assert.lteq(array.access_count, 4)
   end)
 
   it('should return -1 if a value is greater than all elements in a long array', function()
     local array = TracedArray{ 6, 67, 123, 345, 456, 457, 490, 2002, 54321, 54322 }
 
     assert.equal(-1, find(array, 54323))
-    assert(array.access_count <= 4)
+    assert.lteq(array.access_count, 4)
   end)
 end)


### PR DESCRIPTION
When working through the binary-search exercise, my naive solution was not efficient enough and the failure messages displayed to me looked like:

```
 binary-search busted --filter 'longer array'
◼
0 successes / 1 failure / 0 errors / 0 pending : 0.009913 seconds

Failure → ./binary-search_spec.lua @ 33
binary-search should find an element in a longer array in less than log(n) accesses
./binary-search_spec.lua:37: assertion failed!
```

This PR attempts to make the failure message clearer, so that it looks like:

```
 binary-search busted --filter 'longer array'
◼
0 successes / 1 failure / 0 errors / 0 pending : 0.012731 seconds

Failure → ./binary-search_spec.lua @ 33
binary-search should find an element in a longer array in less than log(n) accesses
./binary-search_spec.lua:37: Expected
(number) 10
to be less than or equal to
(number) 9
```

Initially i had to add prints to my solution to figure out how many accesses I'd actually made.