### PR TITLE
bank-account: fix typo in bank-account_spec.lua

### DIFF
--- a/exercises/bank-account/bank-account_spec.lua
+++ b/exercises/bank-account/bank-account_spec.lua
@@ -1,6 +1,6 @@
 local BankAccount = require('bank-account')
 
-describe('bank-ccount', function()
+describe('bank-account', function()
   it('should have a balance of zero after opening a new account', function()
     local account = BankAccount:new()
     assert.equal(0, account:balance())


### PR DESCRIPTION
This typo makes busted show somewhat wrong output.