### PR TITLE
updated/fixed github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,21 +4,21 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
-    - uses: leafo/gh-actions-lua@v6
-      with:
-        luaVersion: "5.3.5"
+      - uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: 5.4
 
-    - uses: leafo/gh-actions-luarocks@v2
+      - uses: leafo/gh-actions-luarocks@v4.0.0
 
-    - name: build
-      run: |
-        luarocks install busted
+      - name: build
+        run: |
+          luarocks install busted
 
-    - name: test
-      run: |
-        bin/test-all
+      - name: test
+        run: |
+          bin/test-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/exercises/allergies/example.lua
+++ b/exercises/allergies/example.lua
@@ -12,7 +12,7 @@ local allergens = {
 local function list(score)
   local results = {}
   for i, allergen in ipairs(allergens) do
-    if bit32.band(score, 1 << (i - 1)) > 0 then
+    if score & 1 << (i - 1) > 0 then
       table.insert(results, allergen)
     end
   end


### PR DESCRIPTION
From [gh-actions-lua](https://github.com/leafo/gh-actions-lua):
> Update Nov 18, 2020: You must use version 8.0.0 or greater as GitHub has deprecated older versions of the actions core libraries.

* using latest versions of [gh-actions-lua](https://github.com/leafo/gh-actions-lua) and [gh-actions-luarocks](https://github.com/leafo/gh-actions-luarocks)
* using lua version 5.4
* using ubuntu-latest