### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Lua (pronounced __LOO-ah__, which means *Moon* in Portuguese) is a simple yet powerful, lightweight, fast, portable and embeddable scripting language.
 It is designed, implemented, and maintained by a [team](https://www.lua.org/authors.html) at [PUC-Rio](https://www.puc-rio.br/) and is housed at [LabLua](http://www.lua.inf.puc-rio.br/).
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -5,7 +5,7 @@
 - [Windows 10: WSL](#windows-10%-wsl)
 - [Windows 10: Docker](#windows-10%-docker)
 
-#### MacOS
+## MacOS
 
 First install Lua and [Luarocks][2] using [Homebrew][1]:
 
@@ -25,7 +25,7 @@ Then run your tests:
 $ busted
 ```
 
-#### Ubuntu
+## Ubuntu
 
 First install Lua and [Luarocks][2] using [Apt][6]:
 
@@ -51,7 +51,7 @@ Then run your tests:
 $ busted
 ```
 
-#### Windows 10: WSL
+## Windows 10: WSL
 
 First you must enable [WSL (Windows Subsystem for Linux)][7] using [PowerShell][8] (Administrator):
 
@@ -84,16 +84,16 @@ Once done you can run your tests directly from any Windows command line:
 C:\> wsl busted
 ```
 
-#### Windows 10: Docker
+## Windows 10: Docker
 
-##### Install Gitbash
+### Install Gitbash
 
 This step is optional. You may have to tweak the following steps slightly if you prefer to use Windows' native CLI or another CLI.
 
 Download [here][10].
 Install Instructions [here][11].
 
-##### Install Docker
+### Install Docker
 
 Follow the instructions to install [Docker for Windows][12].
 Once you've finished installing, you can run the following command to ensure it's been installed correctly.
@@ -108,7 +108,7 @@ _You may encounter an error when trying to run Docker the first time._
 
 _If this occurs, you can follow these instructions to [enable Hyper V][13]. You may have to disable the setting, restart your computer and re-enable it after boot._
 
-##### Install busted
+### Install busted
 
 Once you have Gitbash and Docker installed, you'll be able to install a busted 'container'.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installing Lua
+# Installing Lua
 
 - [MacOS](#macos)
 - [Ubuntu](#ubuntu)

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Lua is a very small language and you can [learn the basics of the language in 15 minutes][1]. For an exhaustive look at the language, written by the authors of Lua, you can read [Programming in Lua][2] (the first edition which covers Lua 5.1 [is available online for free][3]).
 
 [1]: http://tylerneylon.com/a/learn-lua/

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 There are many great free online resources for Lua including:
 
 1.  [lua.org][8]

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Run your tests with
 
     $ busted


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
