### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "3184490d-d638-4dd0-a74d-672818c3f64a",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Lua locally",
+      "blurb": "Learn how to install Lua locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "f6e51cf1-6f86-43fd-a6ab-a653b7fa4604",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Lua",
+      "blurb": "An overview of how to get started from scratch with Lua"
+    },
+    {
+      "uuid": "b5cb8aef-32d4-40f7-9a89-cf28dd2182ab",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Lua track",
+      "blurb": "Learn how to test your Lua exercises on Exercism"
+    },
+    {
+      "uuid": "7d78ec76-ed6b-46ef-80e3-9e13878677db",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Lua resources",
+      "blurb": "A collection of useful resources to help you master Lua"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
