### PR TITLE
Fix typo in bank-account tests

### DIFF
--- a/exercises/practice/bank-account/bank-account_spec.lua
+++ b/exercises/practice/bank-account/bank-account_spec.lua
@@ -76,7 +76,7 @@ describe('bank-account', function()
     account:close()
   end)
 
-  it('should now allow deposits to a closed account', function()
+  it('should not allow deposits to a closed account', function()
     local account = BankAccount:new()
     account:close()
     assert.has.errors(function()


### PR DESCRIPTION
Small typo in the tests, which unfortunately suggests the opposite meaning. 