### PR TITLE
Fix unparsable indentation in spec for test runner

### DIFF
--- a/exercises/practice/nucleotide-count/nucleotide-count_spec.lua
+++ b/exercises/practice/nucleotide-count/nucleotide-count_spec.lua
@@ -13,7 +13,7 @@ describe('nucleotide-count', function()
     local expected = 0
     result = dna:count('A')
     assert.are.same(expected, result)
- end)
+  end)
 
   it('repetitive cytosine gets counts', function()
     local dna = DNA:new('CCCCC')


### PR DESCRIPTION
Function [`parse_test_file`](https://github.com/exercism/lua-test-runner/blob/66c56800e16e3123d4c7eb1dc81788f22d87d508/handler/exercism.lua#L12) in test runner could not parse the spec file due to the typo in indentation.

This leads to correct solutions being reported as "Failed" on https://exercism.org/tracks/lua/exercises/nucleotide-count.