### PR TITLE
Update the testing doc that's included in the downloaded HELP.md

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,3 +1,7 @@
 # Tests
 
 To run the tests, run the command `busted` from within the exercise directory.
+
+Refer to the [Installing Lua locally][install] documentation to get Lua and busted installed correctly.
+
+[install]: https://exercism.org/docs/tracks/lua/installation


### PR DESCRIPTION
My previous PR #350 will affect the website's Lua track docs.

This change manifests in the downloaded HELP.md file (https://exercism.org/docs/building/tracks/presentation#h-help-md)