### PR TITLE
Update crypto-square_spec.lua

### DIFF
--- a/exercises/practice/crypto-square/crypto-square_spec.lua
+++ b/exercises/practice/crypto-square/crypto-square_spec.lua
@@ -80,13 +80,13 @@ describe('crypto-square', function()
 
     it('should generate normalized ciphertext with a short segment', function()
       assert.equal(
-        'msemo aanin dnin ndla etlt shui',
+        'msemo aanin dnin  ndla  etlt  shui ',
         cs.normalized_ciphertext('Madness, and then illumination.')
       )
     end)
 
     it('should generate normalized ciphertext when just less than a full square', function()
-      assert.equal('im a', cs.normalized_ciphertext('I am'))
+      assert.equal('im a ', cs.normalized_ciphertext('I am'))
     end)
   end)
 end)


### PR DESCRIPTION
The test cases of the crypto square exercise don't match the description or other languages. The description states that
rows should be padded with trailing spaces:

> For phrases that are `n` characters short of the perfect rectangle, pad each of the last `n`
> chunks with a single trailing space.
> 
> ```text
> "imtgdvs fearwer mayoogo anouuio ntnnlvt wttddes aohghn  sseoau "
> ```

But the test cases expect a different behaviour:

> ```lua
> it('should generate normalized ciphertext with a short segment', function()
>   assert.equal(
>     'msemo aanin dnin ndla etlt shui',
>     cs.normalized_ciphertext('Madness, and then illumination.')
>   )
> end)
> 
> it('should generate normalized ciphertext when just less than a full square', function()
>   assert.equal('im a', cs.normalized_ciphertext('I am'))
> end)
> ```

This PR updates the test cases to match the description. This would invalidate all of the solutions currently submitted.