### PR TITLE
Deprecate beer-song

### DIFF
--- a/config.json
+++ b/config.json
@@ -384,7 +384,8 @@
           "control_flow_loops",
           "strings",
           "text_formatting"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "food-chain",


### PR DESCRIPTION
This slug was deprecated last year in favor of bottle-song, which has now been implemented.

See https://github.com/exercism/problem-specifications/blob/main/exercises/beer-song/.deprecated