### PR TITLE
Use snake case instead of camel case for function names

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/example.lua
+++ b/exercises/practice/armstrong-numbers/.meta/example.lua
@@ -1,6 +1,6 @@
 local ArmstrongNumbers = {}
 
-function ArmstrongNumbers.isArmstrongNumber(number)
+function ArmstrongNumbers.is_armstrong_number(number)
     local digits = tostring(number)
     local pow_special = function(digit) return tonumber(digit) ^ string.len(digits) end
 

--- a/exercises/practice/armstrong-numbers/armstrong-numbers.lua
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers.lua
@@ -1,6 +1,6 @@
 local ArmstrongNumbers = {}
 
-function ArmstrongNumbers.isArmstrongNumber(number)
+function ArmstrongNumbers.is_armstrong_number(number)
 
 end
 

--- a/exercises/practice/armstrong-numbers/armstrong-numbers_spec.lua
+++ b/exercises/practice/armstrong-numbers/armstrong-numbers_spec.lua
@@ -2,38 +2,38 @@ local ArmstrongNumbers = require 'armstrong-numbers'
 
 describe('armstrong-nunbers', function()
   it('Zero is an Armstrong number', function()
-    assert.is_true(ArmstrongNumbers.isArmstrongNumber(0))
+    assert.is_true(ArmstrongNumbers.is_armstrong_number(0))
   end)
 
   it('Single-digit numbers are Armstrong numbers', function()
-    assert.is_true(ArmstrongNumbers.isArmstrongNumber(5))
+    assert.is_true(ArmstrongNumbers.is_armstrong_number(5))
   end)
 
   it('There are no two-digit Armstrong numbers', function()
-    assert.is_false(ArmstrongNumbers.isArmstrongNumber(10))
+    assert.is_false(ArmstrongNumbers.is_armstrong_number(10))
   end)
 
   it('Three-digit number that is an Armstrong number', function()
-    assert.is_true(ArmstrongNumbers.isArmstrongNumber(153))
+    assert.is_true(ArmstrongNumbers.is_armstrong_number(153))
   end)
 
   it('Three-digit number that is not an Armstrong number', function()
-    assert.is_false(ArmstrongNumbers.isArmstrongNumber(100))
+    assert.is_false(ArmstrongNumbers.is_armstrong_number(100))
   end)
 
   it('Four-digit number that is an Armstrong number', function()
-    assert.is_true(ArmstrongNumbers.isArmstrongNumber(9474))
+    assert.is_true(ArmstrongNumbers.is_armstrong_number(9474))
   end)
 
   it('Four-digit number that is not an Armstrong number', function()
-    assert.is_false(ArmstrongNumbers.isArmstrongNumber(9475))
+    assert.is_false(ArmstrongNumbers.is_armstrong_number(9475))
   end)
 
   it('Seven-digit number that is an Armstrong number', function()
-    assert.is_true(ArmstrongNumbers.isArmstrongNumber(9926315))
+    assert.is_true(ArmstrongNumbers.is_armstrong_number(9926315))
   end)
 
   it('Seven-digit number that is not an Armstrong number', function()
-    assert.is_false(ArmstrongNumbers.isArmstrongNumber(9926314))
+    assert.is_false(ArmstrongNumbers.is_armstrong_number(9926314))
   end)
 end)

--- a/exercises/practice/pop-count/.meta/example.lua
+++ b/exercises/practice/pop-count/.meta/example.lua
@@ -1,6 +1,6 @@
 local PopCount = {}
 
-function PopCount.eggCount(number)
+function PopCount.egg_count(number)
     local eggs = 0
 
     local current = number

--- a/exercises/practice/pop-count/pop-count.lua
+++ b/exercises/practice/pop-count/pop-count.lua
@@ -1,6 +1,6 @@
 local PopCount = {}
 
-function PopCount.eggCount(number)
+function PopCount.egg_count(number)
 
 end
 

--- a/exercises/practice/pop-count/pop-count_spec.lua
+++ b/exercises/practice/pop-count/pop-count_spec.lua
@@ -2,18 +2,18 @@ local PopCount = require 'pop-count'
 
 describe('pop-count', function()
   it('0 eggs', function()
-    assert.equal(0, PopCount.eggCount(0))
+    assert.equal(0, PopCount.egg_count(0))
   end)
 
   it('1 egg', function()
-    assert.equal(1, PopCount.eggCount(16))
+    assert.equal(1, PopCount.egg_count(16))
   end)
 
   it('4 eggs', function()
-    assert.equal(4, PopCount.eggCount(89))
+    assert.equal(4, PopCount.egg_count(89))
   end)
 
   it('13 eggs', function()
-    assert.equal(13, PopCount.eggCount(2000000000))
+    assert.equal(13, PopCount.egg_count(2000000000))
   end)
 end)

--- a/exercises/practice/square-root/.meta/example.lua
+++ b/exercises/practice/square-root/.meta/example.lua
@@ -1,6 +1,6 @@
 local SquareRoot = {}
 
-function SquareRoot.squareRoot(radicand)
+function SquareRoot.square_root(radicand)
     local root = 0
     while root ^ 2 ~= radicand do
         root = root + 1

--- a/exercises/practice/square-root/square-root.lua
+++ b/exercises/practice/square-root/square-root.lua
@@ -1,6 +1,6 @@
 local SquareRoot = {}
 
-function SquareRoot.squareRoot(radicand)
+function SquareRoot.square_root(radicand)
 
 end
 

--- a/exercises/practice/square-root/square-root_spec.lua
+++ b/exercises/practice/square-root/square-root_spec.lua
@@ -2,26 +2,26 @@ local SquareRoot = require 'square-root'
 
 describe('square-root', function()
   it('root of 1', function()
-    assert.equal(1, SquareRoot.squareRoot(1))
+    assert.equal(1, SquareRoot.square_root(1))
   end)
 
   it('root of 4', function()
-    assert.equal(2, SquareRoot.squareRoot(4))
+    assert.equal(2, SquareRoot.square_root(4))
   end)
 
   it('root of 25', function()
-    assert.equal(5, SquareRoot.squareRoot(25))
+    assert.equal(5, SquareRoot.square_root(25))
   end)
 
   it('root of 81', function()
-    assert.equal(9, SquareRoot.squareRoot(81))
+    assert.equal(9, SquareRoot.square_root(81))
   end)
 
   it('root of 196', function()
-    assert.equal(14, SquareRoot.squareRoot(196))
+    assert.equal(14, SquareRoot.square_root(196))
   end)
 
   it('root of 65025', function()
-    assert.equal(255, SquareRoot.squareRoot(65025))
+    assert.equal(255, SquareRoot.square_root(65025))
   end)
 end)

--- a/exercises/practice/two-fer/.meta/example.lua
+++ b/exercises/practice/two-fer/.meta/example.lua
@@ -1,6 +1,6 @@
 local TwoFer = {}
 
-function TwoFer.twoFer(name)
+function TwoFer.two_fer(name)
     local val = name or 'you'
     return string.format('One for %s, one for me.', val)
 end

--- a/exercises/practice/two-fer/two-fer.lua
+++ b/exercises/practice/two-fer/two-fer.lua
@@ -1,6 +1,6 @@
 local TwoFer = {}
 
-function TwoFer.twoFer(name)
+function TwoFer.two_fer(name)
 
 end
 

--- a/exercises/practice/two-fer/two-fer_spec.lua
+++ b/exercises/practice/two-fer/two-fer_spec.lua
@@ -2,14 +2,14 @@ local TwoFer = require 'two-fer'
 
 describe('two-fer', function()
   it('no name given', function()
-    assert.equal('One for you, one for me.', TwoFer.twoFer())
+    assert.equal('One for you, one for me.', TwoFer.two_fer())
   end)
 
   it('a name given', function()
-    assert.equal('One for Alice, one for me.', TwoFer.twoFer('Alice'))
+    assert.equal('One for Alice, one for me.', TwoFer.two_fer('Alice'))
   end)
 
   it('another name given', function()
-    assert.equal('One for Bob, one for me.', TwoFer.twoFer('Bob'))
+    assert.equal('One for Bob, one for me.', TwoFer.two_fer('Bob'))
   end)
 end)


### PR DESCRIPTION
This fixes formatting inconsistencies with the other exercises in the track