### PR TITLE
Corrected test description for disjoint sets.

### DIFF
--- a/exercises/practice/custom-set/custom-set_spec.lua
+++ b/exercises/practice/custom-set/custom-set_spec.lua
@@ -64,7 +64,7 @@ describe('custom-set', function()
       assert.is_true(Set():is_disjoint(Set(1)))
     end)
 
-    it('should indicate that a non-empty set is not disjoint with an empty set', function()
+    it('should indicate that a non-empty set is disjoint with an empty set', function()
       assert.is_true(Set(1):is_disjoint(Set()))
     end)
 


### PR DESCRIPTION
 Was a typo declaring non empty set as not disjoint with empty set.  Now correctly states that it should be disjoint.

Closes #433 