### PR TITLE
Add .busted to fix lasagna tests

### DIFF
--- a/exercises/concept/lasagna/.busted
+++ b/exercises/concept/lasagna/.busted
@@ -1,0 +1,5 @@
+return {
+  default = {
+    ROOT = { '.' }
+  }
+}

--- a/exercises/concept/lasagna/lasagna_spec.lua
+++ b/exercises/concept/lasagna/lasagna_spec.lua
@@ -1,7 +1,7 @@
 local lasagna = require('lasagna')
 
 describe('lasagna', function()
-  it('should have a oven_time field with the correct value', function()
+  it('should have an oven_time field with the correct value', function()
     assert.are.equal(40, lasagna.oven_time)
   end)
 


### PR DESCRIPTION
Without this, `busted` expects the tests to be in `spec/`:

![image](https://github.com/exercism/lua/assets/2488333/16477160-eea4-4e58-b8b9-a0b722994a96)