### PR TITLE
Update instructions.md for Lua error handling

### DIFF
--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -26,4 +26,9 @@ a + c ≥ b
 
 See [Triangle Inequality][triangle-inequality]
 
+### Error handling
+
+If the shape is no triangle at all, throw an error using the [Error Keyword][error-keyword]
+
 [triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality
+[error-keyword]: https://www.lua.org/manual/5.4/manual.html#pdf-error

--- a/exercises/practice/triangle/.docs/instructions.md
+++ b/exercises/practice/triangle/.docs/instructions.md
@@ -26,9 +26,13 @@ a + c ≥ b
 
 See [Triangle Inequality][triangle-inequality]
 
-### Error handling
+### Error handling & Assertion
 
-If the shape is no triangle at all, throw an error using the [Error Keyword][error-keyword]
+Use error handling or assertion to check if the shape is a triangle at all:
+
+- [Error Keyword][error-keyword]
+- [Assertion][assertion]
 
 [triangle-inequality]: https://en.wikipedia.org/wiki/Triangle_inequality
 [error-keyword]: https://www.lua.org/manual/5.4/manual.html#pdf-error
+[assertion]: https://www.lua.org/manual/5.4/manual.html#pdf-assert


### PR DESCRIPTION
The instructions did not mention that the use of the error keyword is required. In addition, following the Concepts up to this exercise did not mention the error keyword, as such additional instructions have been added.

#496 

Edit: https://forum.exercism.org/t/mentioning-of-the-error-keyword/12686