### PR TITLE
move OOP article link off-site

### DIFF
--- a/exercises/practice/high-scores/.docs/instructions.append.md
+++ b/exercises/practice/high-scores/.docs/instructions.append.md
@@ -4,4 +4,4 @@
 
 You can read more about OO programming in Lua [in this article][oop].
 
-[oop]: https://exercism.org/tracks/lua/exercises/high-scores/articles/oop
+[oop]: https://glennj.github.io/exercism/lua/oop


### PR DESCRIPTION
I copied the article to my GitHub.io -- https://glennj.github.io/exercism/lua/oop