### PR TITLE
Spec generator - Respect tests.toml

### DIFF
--- a/bin/generate-spec
+++ b/bin/generate-spec
@@ -42,6 +42,7 @@ package.path = package.path .. ';' .. exercise_directory .. '/.meta/?.lua'
 local canonical_data_url = 'https://raw.githubusercontent.com/exercism/problem-specifications/main/exercises/' .. exercise_name .. '/canonical-data.json'
 local canonical_data_path = 'canonical-data/' .. exercise_name .. '.json'
 local spec_path = exercise_directory .. '/' .. exercise_name .. '_spec.lua'
+local tests_toml_path = exercise_directory .. '/.meta/tests.toml'
 
 assert(os.execute('mkdir -p `dirname ' .. canonical_data_path .. '`'))
 assert(os.execute('curl ' .. canonical_data_url .. ' -s -o ' .. canonical_data_path))
@@ -51,7 +52,7 @@ local canonical_data = json.decode(canonical_data_json)
 
 local spec_generator = require('spec_generator')
 
-local included_tests = included_tests_from_toml(exercise_directory .. '/.meta/tests.toml')
+local included_tests = included_tests_from_toml(tests_toml_path)
 
 local function process(node)
   if node.cases then

--- a/bin/generate-spec
+++ b/bin/generate-spec
@@ -20,7 +20,7 @@ local function included_tests_from_toml(path)
   local last_uuid
 
   for line in io.lines(path) do
-    for uuid in line:gmatch('%[(.+)%]') do
+    for uuid in line:gmatch('%[([%x%-]+)%]') do
       last_uuid = uuid
       included[uuid] = true
     end

--- a/bin/generate-spec
+++ b/bin/generate-spec
@@ -15,6 +15,24 @@ local function write_file(path, contents)
   f:close()
 end
 
+local function included_tests_from_toml(path)
+  local included = {}
+  local last_uuid
+
+  for line in io.lines(path) do
+    for uuid in line:gmatch('%[(.+)%]') do
+      last_uuid = uuid
+      included[uuid] = true
+    end
+
+    if line:match('^include%s*=%s*false') then
+      included[last_uuid] = nil
+    end
+  end
+
+  return included
+end
+
 local exercise_name = arg[1]
 
 local exercise_directory = 'exercises/practice/' .. exercise_name
@@ -33,6 +51,8 @@ local canonical_data = json.decode(canonical_data_json)
 
 local spec_generator = require('spec_generator')
 
+local included_tests = included_tests_from_toml(exercise_directory .. '/.meta/tests.toml')
+
 local function process(node)
   if node.cases then
     local output = {}
@@ -49,7 +69,9 @@ local function process(node)
 
     local cases = {}
     for _, case in ipairs(node.cases) do
-      table.insert(cases, process(case))
+      if not case.uuid or included_tests[case.uuid] then
+        table.insert(cases, process(case))
+      end
     end
     table.insert(output, table.concat(cases, '\n\n'))
 

--- a/exercises/practice/book-store/book-store_spec.lua
+++ b/exercises/practice/book-store/book-store_spec.lua
@@ -76,12 +76,11 @@ describe('book-store', function()
     assert.are.same(10240, book_store.total(basket))
   end)
 
-  -- LuaFormatter off
-  it('check that groups of four are created properly even when there are more groups of three than groups of five', function()
+  it('check that groups of four are created properly even when there are more groups of three than groups of five',
+     function()
     local basket = { 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 5, 5 }
     assert.are.same(14560, book_store.total(basket))
   end)
-  -- LuaFormatter on
 
   it('one group of one and four is cheaper than one group of two and three', function()
     local basket = { 1, 1, 2, 3, 4 }

--- a/exercises/practice/state-of-tic-tac-toe/state-of-tic-tac-toe_spec.lua
+++ b/exercises/practice/state-of-tic-tac-toe/state-of-tic-tac-toe_spec.lua
@@ -67,15 +67,6 @@ describe('state-of-tic-tac-toe', function()
 
     it('finished game where x won via middle row victory', function()
       local board = {
-        'O O', --
-        'XXX', --
-        ' O ' --
-      }
-      assert.are.same('win', state_of_tic_tac_toe.gamestate(board))
-    end)
-
-    it('finished game where x won via middle row victory', function()
-      local board = {
         'O  ', --
         'XXX', --
         ' O ' --


### PR DESCRIPTION
In https://github.com/exercism/lua/pull/523, @keiravillekode mentioned that the `reimplements` was handled by manually updating the generated spec. This updates the spec generator so that only tests included via `tests.toml` are included in the generated spec.