### PR TITLE
Deprecate binary and octal exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -342,7 +342,8 @@
           "control_flow_loops",
           "math",
           "strings"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "bob",
@@ -869,7 +870,8 @@
           "control_flow_loops",
           "math",
           "strings"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "prime-factors",


### PR DESCRIPTION
These exercises have been replaced by all-your-base https://github.com/exercism/problem-specifications/issues/279

resolves #532