### PR TITLE
Fix test dates for gigasecond

### DIFF
--- a/exercises/practice/gigasecond/gigasecond_spec.lua
+++ b/exercises/practice/gigasecond/gigasecond_spec.lua
@@ -14,8 +14,8 @@ describe('gigasecond', function()
   end)
 
   it('test 3', function()
-    local actual = gigasecond.anniversary(os.time({ year = 1959, month = 7, day = 19 }))
-    local expectedDate = os.date('%x', os.time({ year = 1991, month = 3, day = 27 }))
+    local actual = gigasecond.anniversary(os.time({ year = 2009, month = 1, day = 19 }))
+    local expectedDate = os.date('%x', os.time({ year = 2040, month = 9, day = 27 }))
     assert.are.equals(expectedDate, actual)
   end)
 

--- a/exercises/practice/gigasecond/gigasecond_spec.lua
+++ b/exercises/practice/gigasecond/gigasecond_spec.lua
@@ -14,8 +14,8 @@ describe('gigasecond', function()
   end)
 
   it('test 3', function()
-    local actual = gigasecond.anniversary(os.time({ year = 2009, month = 1, day = 19 }))
-    local expectedDate = os.date('%x', os.time({ year = 2040, month = 9, day = 27 }))
+    local actual = gigasecond.anniversary(os.time({ year = 1999, month = 7, day = 19 }))
+    local expectedDate = os.date('%x', os.time({ year = 2031, month = 3, day = 27 }))
     assert.are.equals(expectedDate, actual)
   end)
 


### PR DESCRIPTION
This pull request updates the gigasecond exercise tests to use dates that are supported by Lua’s ``os.time``. Previously, test 3 used the date 1959-07-19, which caused ``os.time`` to return nil and made the ``any_date`` parameter in ``gigasecond.anniversary`` nil. The test has now been updated to use 2009-01-19, which allows the function to correctly calculate the gigasecond anniversary and ensures the test passes as intended.