### PR TITLE
examples valid with Lua 5.4

### DIFF
--- a/exercises/practice/gigasecond/.meta/example.lua
+++ b/exercises/practice/gigasecond/.meta/example.lua
@@ -3,7 +3,7 @@
 local gigasecond = {}
 
 function gigasecond.anniversary(any_date)
-  return os.date('!%x', any_date + math.pow(10, 9))
+  return os.date('!%x', any_date + 10 ^ 9)
 end
 
 return gigasecond

--- a/exercises/practice/run-length-encoding/.meta/example.lua
+++ b/exercises/practice/run-length-encoding/.meta/example.lua
@@ -14,10 +14,8 @@ return {
   decode = function(s)
     local result = ''
     for length, c in s:gmatch('(%d*)(.)') do
-      if length == '' then
-        length = 1
-      end
-      result = result .. c:rep(length)
+      local n = (length == '') and 1 or tonumber(length)
+      result = result .. c:rep(n)
     end
     return result
   end


### PR DESCRIPTION
Lua 5.4 removed math.pow, and made reassignment to loop variables a runtime error.  We replace example code in gigasecond and run-length-encoding.