### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,3 +1,7 @@
+# Instructions append
+
+## Implementation
+
 This exercise requires you to use Closure-based objects. You can read more about this approach to object orientation in Lua [in this article][oot].
 
 This exercise also requires you to use operator overloading via metatable metamethods. You can read more about this in [Programming in Lua][am].

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For this exercise, returning the list of colors is not required.

--- a/exercises/practice/triangle/.docs/instructions.append.md
+++ b/exercises/practice/triangle/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-### Error handling & Assertion
+## Error handling & Assertion
 
 Use error handling or assertion to check if the shape is a triangle at all:
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.